### PR TITLE
Update version and repository links for joker packages

### DIFF
--- a/packages/joker/CHANGELOG.md
+++ b/packages/joker/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.0-dev.3
+
+### Changed
+
+- Updated `pubspec.yaml` files to set version to `0.1.0-dev.3` and added repository links.
+
 ## 0.1.0-dev.2
 
 ### Added

--- a/packages/joker/pubspec.yaml
+++ b/packages/joker/pubspec.yaml
@@ -1,9 +1,9 @@
 name: joker
 description: HTTP request stubbing and mocking library for Dart. Intercept HTTP requests from any library using HttpOverrides.
-version: 0.1.0-dev.2
-homepage: https://github.com/juanvegu/joker_dart
-repository: https://github.com/juanvegu/joker_dart
+version: 0.1.0-dev.3
 resolution: workspace
+homepage: https://github.com/juanvegu/joker_dart
+repository: https://github.com/juanvegu/joker_dart/tree/main/packages/joker
 
 environment:
   sdk: ^3.9.0

--- a/packages/joker_dio/pubspec.yaml
+++ b/packages/joker_dio/pubspec.yaml
@@ -1,10 +1,9 @@
 name: joker_dio
 description: A starting point for Dart libraries or applications.
 version: 0.0.1
-homepage: https://github.com/juanvegu/joker_dart
-repository: https://github.com/juanvegu/joker_dart
 resolution: workspace
-
+homepage: https://github.com/juanvegu/joker_dart
+repository: https://github.com/juanvegu/joker_dart/tree/main/packages/joker_dio
 environment:
   sdk: ^3.9.0
 

--- a/packages/joker_http/pubspec.yaml
+++ b/packages/joker_http/pubspec.yaml
@@ -1,9 +1,9 @@
 name: joker_http
 description: A starting point for Dart libraries or applications.
 version: 0.0.1
-homepage: https://github.com/juanvegu/joker_dart
-repository: https://github.com/juanvegu/joker_dart
 resolution: workspace
+homepage: https://github.com/juanvegu/joker_dart
+repository: https://github.com/juanvegu/joker_dart/tree/main/packages/joker_http
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
Set the version to `0.1.0-dev.3` in the `pubspec.yaml` files and updated repository links in the documentation.